### PR TITLE
Add announcements modal, minor tweaks

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,22 @@
 // C:\Ron\AllIn\frontend\src\App.jsx
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Outlet } from 'react-router-dom';
 import Home from './pages/Home';
 import AiGame from './pages/AiGame';
 import StrategyLookup from './pages/StrategyLookup';
 import AuthCallback from './pages/AuthCallback';
 import NotFound from './pages/NotFound';
+import { AnnouncementsProvider } from './components/Announcements';
+
+// Root layout: wraps every route in the announcements provider (which owns the
+// modal + auto-open + "seen" state). The trigger button lives in each page's
+// own top-right header, next to the account control (AnnouncementsButton).
+function RootLayout() {
+  return (
+    <AnnouncementsProvider>
+      <Outlet />
+    </AnnouncementsProvider>
+  );
+}
 
 // Data router (createBrowserRouter) rather than the declarative <BrowserRouter>,
 // so AiGame can use `useBlocker` to intercept in-app navigation away from a live
@@ -18,6 +30,7 @@ import NotFound from './pages/NotFound';
 const router = createBrowserRouter([
   {
     path: '/',
+    element: <RootLayout />,
     errorElement: <NotFound />,
     children: [
       { index: true, element: <Home /> },

--- a/frontend/src/announcements.jsx
+++ b/frontend/src/announcements.jsx
@@ -1,0 +1,41 @@
+// frontend/src/announcements.jsx
+// Site announcements, NEWEST FIRST. To post one, prepend an entry with a fresh
+// `id` and a `date` string. Everyone whose stored "last seen" id differs from the
+// new top entry auto-sees the modal on their next visit; they can reopen it any
+// time (the speaker button) to scroll back through older announcements.
+import React from 'react';
+
+// Render a bullet list from plain strings (kept as a helper, not a component, so
+// this data-only module doesn't trip the fast-refresh "components only" rule).
+const bullets = (points) => (
+    <ul className="space-y-2.5">
+        {points.map((t, i) => (
+            <li key={i} className="flex gap-2">
+                <span className="text-amber-500 shrink-0">•</span>
+                <span>{t}</span>
+            </li>
+        ))}
+    </ul>
+);
+
+export const ANNOUNCEMENTS = [
+    {
+        id: 'botv2-2026-06-16',
+        date: 'June 16, 2026',
+        title: 'Coming soon: Bot v2',
+        body: (
+            <>
+                <p className="mb-3">Firstly, thanks for playing! I have a few updates:</p>
+                {bullets([
+                    'Bot v2 in the next few days: a 90M iteration retrain on a finer '
+                        + 'abstraction, so it comes back a little stronger.',
+                    'A turn solver is in the works to deepen its play.',
+                    'More stats are coming to the front page: compare Bot v1 and v2, plus some of your own.',
+                    'Plus a few fixes along the way.',
+                ])}
+                <p className="mt-3">Stay tuned,</p>
+                <p className="font-medium text-amber-300/90">Ron</p>
+            </>
+        ),
+    },
+];

--- a/frontend/src/components/AnnouncementModal.jsx
+++ b/frontend/src/components/AnnouncementModal.jsx
@@ -1,0 +1,71 @@
+// frontend/src/components/AnnouncementModal.jsx
+// "Announcements" modal: shows every announcement newest-first (scroll back for
+// older ones), same visual style as the IntroModal help screen. This is the
+// presentation only; the open/auto-open/"dismissed" state lives in
+// Announcements.jsx (AnnouncementsProvider). `onClose(dontShow)` reports the
+// "Don't show this again" checkbox. Content lives in src/announcements.jsx.
+import React, { useState } from 'react';
+
+// Megaphone icon (lucide-style), reused by the top-bar "Announcements" button.
+export function Megaphone({ className = 'w-3.5 h-3.5' }) {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"
+            strokeLinecap="round" strokeLinejoin="round" className={className} aria-hidden="true">
+            <path d="m3 11 18-5v12L3 14v-3z" />
+            <path d="M11.6 16.8a3 3 0 1 1-5.8-1.6" />
+        </svg>
+    );
+}
+
+function AnnouncementModal({ open, items = [], onClose }) {
+    const [dontShow, setDontShow] = useState(false);
+    if (!open) return null;
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4"
+            onClick={() => onClose(dontShow)}>
+            <div className="w-full max-w-md max-h-[80vh] flex flex-col rounded-2xl
+                            border border-amber-600/40 bg-neutral-900 shadow-2xl"
+                onClick={(e) => e.stopPropagation()}>
+                <div className="flex items-center gap-2 px-6 pt-6 pb-3 shrink-0">
+                    <Megaphone className="w-4 h-4 text-amber-300" />
+                    <h2 className="text-xl font-bold text-amber-300">Announcements</h2>
+                </div>
+                {items.length === 0 ? (
+                    <p className="px-6 pb-6 text-sm text-neutral-500">Nothing here yet.</p>
+                ) : (
+                    // Scrollable history: newest at the top, scroll down for older.
+                    // flex-1 + min-h-0 lets this shrink within the max-h-[80vh] modal so
+                    // it actually scrolls (a flex child won't shrink below its content
+                    // height without min-h-0) instead of overflowing the viewport.
+                    <div className="px-6 overflow-y-auto divide-y divide-neutral-800 min-h-0">
+                        {items.map((a) => (
+                            <article key={a.id} className="py-5">
+                                <div className="text-[11px] uppercase tracking-wider text-neutral-500 mb-1">
+                                    {a.date}
+                                </div>
+                                <h3 className="text-base font-semibold text-amber-200 mb-2">{a.title}</h3>
+                                <div className="text-sm text-neutral-300">{a.body}</div>
+                            </article>
+                        ))}
+                    </div>
+                )}
+                <div className="p-6 pt-4 shrink-0">
+                    <label className="flex items-center gap-2 text-xs text-neutral-400
+                                      cursor-pointer mb-3">
+                        <input type="checkbox" checked={dontShow}
+                            onChange={(e) => setDontShow(e.target.checked)}
+                            className="h-4 w-4 accent-amber-500" />
+                        Don&rsquo;t show this again
+                    </label>
+                    <button onClick={() => onClose(dontShow)}
+                        className="w-full px-5 py-3 rounded-xl font-semibold bg-amber-500
+                                   text-neutral-950 hover:bg-amber-400 transition-colors">
+                        Got it
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default AnnouncementModal;

--- a/frontend/src/components/Announcements.jsx
+++ b/frontend/src/components/Announcements.jsx
@@ -1,0 +1,88 @@
+// frontend/src/components/Announcements.jsx
+// Announcements: a context provider that owns the modal + "seen" state (mounted
+// once in the app root, App.jsx), plus a small header BUTTON dropped next to the
+// account control on each page. Splitting them this way lets the trigger live in
+// every page's top-right header while the modal/auto-open stays single-sourced.
+import React, {
+    createContext, useCallback, useContext, useEffect, useMemo, useState,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+import AnnouncementModal, { Megaphone } from './AnnouncementModal';
+import { ANNOUNCEMENTS } from '../announcements';
+
+// Two independent flags, both keyed to the latest announcement id so a NEW
+// announcement resets both:
+//   dismissed -> set ONLY by "Don't show this again"; stops the Home auto-pop.
+//   viewed    -> set whenever the modal is opened (auto or button); clears the dot.
+const ANNOUNCE_DISMISS_KEY = 'allin_announce_dismissed';
+const ANNOUNCE_VIEWED_KEY = 'allin_announce_viewed';
+const LATEST_ID = ANNOUNCEMENTS[0]?.id || null;
+
+const Ctx = createContext({ open: () => {}, hasUnseen: false });
+
+export function AnnouncementsProvider({ children }) {
+    const { pathname } = useLocation();
+    const [open, setOpen] = useState(false);
+    const [viewed, setViewed] = useState(() => localStorage.getItem(ANNOUNCE_VIEWED_KEY));
+    const hasUnseen = !!LATEST_ID && viewed !== LATEST_ID;
+
+    // Opening the modal (auto-pop OR the header button) marks the latest as viewed,
+    // which clears the unseen dot. Stable identity so the effect/memo below don't
+    // re-run needlessly.
+    const openModal = useCallback(() => {
+        setOpen(true);
+        if (LATEST_ID && localStorage.getItem(ANNOUNCE_VIEWED_KEY) !== LATEST_ID) {
+            localStorage.setItem(ANNOUNCE_VIEWED_KEY, LATEST_ID);
+            setViewed(LATEST_ID);
+        }
+    }, []);
+
+    // Auto-pop ONLY on the Home page (each visit), unless dismissed via "Don't show
+    // this again". Re-runs on pathname change because this provider lives in the
+    // persistent root layout (it doesn't re-mount on navigation like a page does).
+    // The button still opens it manually on every page; only the AUTO-open is Home-only.
+    useEffect(() => {
+        if (LATEST_ID && pathname === '/'
+            && localStorage.getItem(ANNOUNCE_DISMISS_KEY) !== LATEST_ID) {
+            openModal();
+        }
+    }, [pathname, openModal]);
+
+    // "Don't show this again" suppresses the Home auto-pop; a plain close does not.
+    const close = (dontShow) => {
+        setOpen(false);
+        if (dontShow && LATEST_ID) {
+            localStorage.setItem(ANNOUNCE_DISMISS_KEY, LATEST_ID);
+        }
+    };
+
+    // Stable context value so consumers (the button) don't re-render on every
+    // provider render (e.g. each route change).
+    const value = useMemo(() => ({ open: openModal, hasUnseen }), [openModal, hasUnseen]);
+
+    return (
+        <Ctx.Provider value={value}>
+            {children}
+            <AnnouncementModal open={open} items={ANNOUNCEMENTS} onClose={close} />
+        </Ctx.Provider>
+    );
+}
+
+// Header trigger, styled like the "?" help button so it sits next to it / the
+// sign-in control. Shows an amber dot when there's an unseen announcement.
+export function AnnouncementsButton({ className = '' }) {
+    const { open, hasUnseen } = useContext(Ctx);
+    if (ANNOUNCEMENTS.length === 0) return null;
+    return (
+        <button onClick={open} title="Announcements" aria-label="Announcements"
+            className={'relative w-6 h-6 rounded-full border border-neutral-700 '
+                + 'text-neutral-400 hover:text-neutral-200 flex items-center '
+                + 'justify-center shrink-0 ' + className}>
+            <Megaphone />
+            {hasUnseen && (
+                <span className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full
+                                 bg-amber-400 ring-2 ring-neutral-900" />
+            )}
+        </button>
+    );
+}

--- a/frontend/src/components/EvCounter.jsx
+++ b/frontend/src/components/EvCounter.jsx
@@ -1,7 +1,7 @@
 // frontend/src/components/EvCounter.jsx
 // The public "+EV counter": the bot's lifetime record vs the whole field.
-// Polls /api/stats every ~30s. The bot's net is the negation of the human field's
-// net (totalNetBB is the humans' aggregate P/L).
+// Polls /api/stats every 60s (shared across instances, see subscribeStats). The
+// bot's net is the negation of the human field's net (totalNetBB = humans' P/L).
 import React, { useEffect, useState } from 'react';
 import { getStats } from '../api';
 
@@ -10,25 +10,40 @@ const fmtSigned = (bb) => `${bb > 0 ? '+' : ''}${bb.toLocaleString(undefined, {
 })}`;
 const fmtRate = (v) => `${v > 0 ? '+' : ''}${v.toFixed(2)}`;   // BB/hand, 2 dp
 
-function EvCounter({ compact = false }) {
-    const [stats, setStats] = useState(null);
+// Shared poll: ONE /api/stats fetch loop no matter how many EvCounter instances
+// are mounted (e.g. AiGame renders a desktop copy + a mobile copy). Instances
+// subscribe; the 60s interval runs only while at least one is mounted, and a late
+// subscriber immediately receives the last cached value. Errors are swallowed --
+// the cards keep showing dashes and the next tick retries. The counter is a
+// slow-moving lifetime stat, so 60s (with the backend's 5s per-worker cache) is
+// plenty; a player's OWN stats refresh separately (getMe on each hand_over).
+let _stats = null;
+const _subs = new Set();
+let _timer = null;
 
-    useEffect(() => {
-        let alive = true;
-        // Errors are swallowed: the card renders dashes until a poll succeeds
-        // (see the comment below) and the 60s interval keeps retrying.
-        const tick = () => getStats().then((s) => alive && setStats(s))
-            .catch(() => {});
-        tick();
-        // 60s poll. The counter is a slow-moving lifetime stat (the bot's record
-        // vs the field is not seconds-sensitive), and the backend's per-worker
-        // 5s cache means more frequent client polling would barely change the
-        // displayed value anyway. The user's OWN stats (`getMe` in AiGame)
-        // refresh immediately on each hand_over so this poll is the field-aggregate
-        // only.
-        const id = setInterval(tick, 60000);
-        return () => { alive = false; clearInterval(id); };
-    }, []);
+function _tick() {
+    getStats().then((s) => { _stats = s; _subs.forEach((fn) => fn(s)); }).catch(() => {});
+}
+
+function subscribeStats(fn) {
+    _subs.add(fn);
+    if (_stats) fn(_stats);
+    if (_timer === null) {
+        _tick();
+        _timer = setInterval(_tick, 60000);
+    }
+    return () => {
+        _subs.delete(fn);
+        if (_subs.size === 0 && _timer !== null) {
+            clearInterval(_timer);
+            _timer = null;
+        }
+    };
+}
+
+function EvCounter({ compact = false }) {
+    const [stats, setStats] = useState(_stats);
+    useEffect(() => subscribeStats(setStats), []);
 
     // Render the card template even while the API is down: the numeric slots
     // show dashes (the same as the loading state) rather than the whole card

--- a/frontend/src/components/IntroModal.jsx
+++ b/frontend/src/components/IntroModal.jsx
@@ -25,7 +25,7 @@ function IntroModal({ open, onClose }) {
             <div className="w-full max-w-md rounded-2xl border border-amber-600/40
                             bg-neutral-900 p-6 shadow-2xl"
                 onClick={(e) => e.stopPropagation()}>
-                <h2 className="text-xl font-bold text-amber-300 mb-4">Welcome to AllIn</h2>
+                <h2 className="text-xl font-bold text-amber-300 mb-4">Welcome to AllIn: Play with AI</h2>
                 <ul className="space-y-2.5 text-sm text-neutral-300">
                     {BULLETS.map((b, i) => (
                         <li key={i} className="flex gap-2">

--- a/frontend/src/pages/AiGame.jsx
+++ b/frontend/src/pages/AiGame.jsx
@@ -14,6 +14,7 @@ import PlayingCard from '../components/PlayingCard';
 import EvCounter from '../components/EvCounter';
 import IntroModal from '../components/IntroModal';
 import LoginPrompt from '../components/LoginPrompt';
+import { AnnouncementsButton } from '../components/Announcements';
 import GoogleSignInButton from '../components/GoogleSignInButton';
 
 // Standardized snake_case localStorage key (matches the other allin_* keys
@@ -558,7 +559,7 @@ function AiGame() {
         return (
             <div className="min-h-screen flex flex-col items-center justify-center
                             bg-[radial-gradient(ellipse_at_center,#0c2a1f_0%,#0a0a0a_72%)]">
-                <h1 className="text-2xl font-bold mb-2">Play With AI</h1>
+                <h1 className="text-2xl font-bold mb-2">Play with AI</h1>
                 {error
                     ? (
                         <>
@@ -659,7 +660,7 @@ function AiGame() {
                         <Link to="/" className="text-sm text-amber-400 hover:text-amber-300">
                             ← Home
                         </Link>
-                        <h1 className="text-xl sm:text-2xl font-bold">Play With AI</h1>
+                        <h1 className="text-xl sm:text-2xl font-bold">Play with AI</h1>
                         {/* Bot record + your lifetime P/L, stacked under the title.
                             Hidden on phones (they don't fit beside the right-side
                             cluster); shown there in a full-width strip below the bar. */}
@@ -679,6 +680,7 @@ function AiGame() {
                                 {showDebug ? 'Debug ✓' : 'Debug'}
                             </button>
                         )}
+                        <AnnouncementsButton />
                         <GoogleSignInButton registered={account?.isRegistered}
                             handle={account?.handle} />
                     </div>

--- a/frontend/src/pages/AuthCallback.jsx
+++ b/frontend/src/pages/AuthCallback.jsx
@@ -87,7 +87,7 @@ function AuthCallback() {
             {state === 'done' && (
                 <>
                     <h1 className="text-2xl font-bold text-amber-300 mb-2">
-                        {row?.handle ? `Welcome back, ${row.handle}` : 'Signed in'}
+                        {row?.handle ? `You're in, ${row.handle}` : 'Signed in'}
                     </h1>
                     <p className="text-neutral-400 mb-6 tabular-nums">
                         You&rsquo;ve played {(row?.hands || 0).toLocaleString()} hands

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import Logo from "./AllIn_Black_Centered.png";
 import EvCounter from "../components/EvCounter";
 import Leaderboard from "../components/Leaderboard";
 import GoogleSignInButton from "../components/GoogleSignInButton";
+import { AnnouncementsButton } from "../components/Announcements";
 import { getPlayerId, getAccount } from "../api";
 
 function Home() {
@@ -24,7 +25,8 @@ function Home() {
 			{/* Header: sign-in / account in the true top-right corner (full-bleed,
 			    like the Play-with-AI page). Players are anonymous until they sign in;
 			    signing in is what puts them on the leaderboard. */}
-			<div className="w-full flex justify-end mb-2">
+			<div className="w-full flex justify-end items-center gap-3 mb-2">
+				<AnnouncementsButton />
 				<GoogleSignInButton registered={account?.isRegistered} handle={account?.handle} />
 			</div>
 

--- a/frontend/src/pages/StrategyLookup.jsx
+++ b/frontend/src/pages/StrategyLookup.jsx
@@ -6,6 +6,7 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import HandExplorer from '../components/HandExplorer';
 import KeyExplorer from '../components/KeyExplorer';
+import { AnnouncementsButton } from '../components/Announcements';
 
 const TABS = [
     { id: 'hand', label: 'Hand Explorer' },
@@ -16,35 +17,42 @@ function StrategyLookup() {
     const [tab, setTab] = useState('hand');
 
     return (
-        <div className="min-h-screen flex justify-center
+        <div className="min-h-screen
                         bg-[radial-gradient(ellipse_at_top,#0c2a1f_0%,#0a0a0a_60%)]">
-            <div className="w-full max-w-3xl px-6 py-10">
+            {/* Full-bleed top bar: Home top-left, announcements top-right (matching
+                the other pages); the explorer content below stays centred. */}
+            <div className="w-full px-6 pt-6 flex items-center justify-between">
                 <Link to="/" className="text-sm text-amber-400 hover:text-amber-300">
                     ← Home
                 </Link>
+                <AnnouncementsButton />
+            </div>
 
-                <h1 className="mt-3 text-3xl font-bold tracking-tight">
-                    Strategy Explorer
-                </h1>
-                <p className="text-neutral-400 mt-1">
-                    Inspect what the trained blueprint does in a given situation.
-                </p>
+            <div className="flex justify-center">
+                <div className="w-full max-w-3xl px-6 pb-10 pt-6">
+                    <h1 className="text-3xl font-bold tracking-tight">
+                        Strategy Explorer
+                    </h1>
+                    <p className="text-neutral-400 mt-1">
+                        Inspect what the trained blueprint does in a given situation.
+                    </p>
 
-                <div className="flex gap-1 mt-6 mb-7 border-b border-neutral-800">
-                    {TABS.map((t) => (
-                        <button key={t.id} onClick={() => setTab(t.id)}
-                            className={'px-6 py-2.5 text-sm rounded-t-lg transition-colors ' +
-                                (tab === t.id
-                                    ? 'bg-amber-500 text-neutral-950 font-semibold'
-                                    : 'bg-neutral-900 text-neutral-400 hover:text-neutral-200')}>
-                            {t.label}
-                        </button>
-                    ))}
+                    <div className="flex gap-1 mt-6 mb-7 border-b border-neutral-800">
+                        {TABS.map((t) => (
+                            <button key={t.id} onClick={() => setTab(t.id)}
+                                className={'px-6 py-2.5 text-sm rounded-t-lg transition-colors ' +
+                                    (tab === t.id
+                                        ? 'bg-amber-500 text-neutral-950 font-semibold'
+                                        : 'bg-neutral-900 text-neutral-400 hover:text-neutral-200')}>
+                                {t.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    {/* Each tool keeps its own state; switching tabs does not share it. */}
+                    {tab === 'hand' && <HandExplorer />}
+                    {tab === 'key' && <KeyExplorer />}
                 </div>
-
-                {/* Each tool keeps its own state; switching tabs does not share it. */}
-                {tab === 'hand' && <HandExplorer />}
-                {tab === 'key' && <KeyExplorer />}
             </div>
         </div>
     );


### PR DESCRIPTION
  - Announcements modal + provider + header button (auto-pops on Home only, "Don't show this again", unseen dot clears on view, scroll-back history).
  - AiGame: mobile responsiveness (fluid board, 3-col action grid, compact buttons, mobile stat strip), on-table last-action pills, holding/action label flip, leave-this-hand confirm via data-router useBlocker.
  - Home: re-centered hero gradient, one-line tagline, announcements button.
  - Leaderboard reads BB/hand; AuthCallback greeting "You're in".
  - EvCounter: single shared /api/stats poll across instances.